### PR TITLE
Added wp_head and wp_footer to template files to enable WP plugins

### DIFF
--- a/packages/cra-template-wptheme-typescript/template/public/post_installer.php
+++ b/packages/cra-template-wptheme-typescript/template/public/post_installer.php
@@ -32,6 +32,7 @@
         Learn how to configure a non-root public URL by running `npm run wpbuild`.
     -->
     <title>React WordPress Theme</title>
+    <?php wp_head(); ?>
 </head>
     <body>
     <noscript>
@@ -48,5 +49,6 @@
         To begin the development, run `npm run wpstart` or `yarn wpstart`.
         To create a production bundle, use `npm run wpbuild` or `yarn wpbuild`.
     -->
+    <?php wp_footer(); ?>
     </body>
 </html>

--- a/packages/cra-template-wptheme/template/public/post_installer.php
+++ b/packages/cra-template-wptheme/template/public/post_installer.php
@@ -32,6 +32,7 @@
         Learn how to configure a non-root public URL by running `npm run wpbuild`.
     -->
     <title>React WordPress Theme</title>
+    <?php wp_head(); ?>
 </head>
     <body>
     <noscript>
@@ -48,5 +49,6 @@
         To begin the development, run `npm run wpstart` or `yarn wpstart`.
         To create a production bundle, use `npm run wpbuild` or `yarn wpbuild`.
     -->
+    <?php wp_footer(); ?>
     </body>
 </html>


### PR DESCRIPTION
Hi!! 😄 

This PR will enable to use WP plugins with react theme.
I've added WP functions (head and footer) in `post_installer.php` file, this will load all plugins styles and scripts if need.